### PR TITLE
Optimize server location example

### DIFF
--- a/docs/client/web-sdk/examples.mdx
+++ b/docs/client/web-sdk/examples.mdx
@@ -435,3 +435,30 @@ await hb.tabs.create({ active: true })
 // Remove the event listener
 hb.tabs.onCreated.removeListener(onTabCreated)
 ```
+
+---
+## 🗺️ Optimize server location
+
+The Hyperbeam Web SDK provides a function called `getRegionInfo()` that returns a two-letter continent code. This code refers to the optimal region to spin up a virtual computer based on the client's location.
+
+To create a session with the optimal server location, you first need to use `getRegionInfo()` on the client to retrieve the optimal continent code.
+
+From there, you need to send it to your backend to use as an argument for the `region` parameter when [creating a session](/rest-api/dispatch/start-chromium-session) and generating an `embed_url`.
+
+<Tip>You may also want to cache the region preference in localStorage, since `getRegionInfo()` fires off a web request.</Tip>
+
+**Example**
+
+```js JavaScript
+import Hyperbeam, {getRegionInfo} from "@hyperbeam/web"
+
+async function createHyperbeam(container) {
+	const region = await getRegionInfo()
+	// Pass region code to backend to be used during session creation
+	const embedURL = await fetch(`/myapi?region=${region}`, {
+		method: "POST"
+	})
+	const hb = Hyperbeam(container, embedURL)
+	return hb
+}
+```

--- a/docs/client/web-sdk/overview.mdx
+++ b/docs/client/web-sdk/overview.mdx
@@ -82,4 +82,7 @@ $ npm install @hyperbeam/web --save
   <Card title="Listen to tab events" icon={<div>👂</div>} color="#a888ff" href="/client/web-sdk/examples#listen-to-tab-events">
     How to listen to tab events.
   </Card>
+  <Card title="Optimize server location" icon={<div>🗺️</div>} color="#a888ff" href="/client/web-sdk/examples#optimize-server-location">
+    How to create a session with the optimal server location.
+  </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Add Optimize server location example to web sdk docs
- Add link to optimize server location example in web sdk overview

## Screenshots

<img width="1632" alt="Screenshot 2023-02-09 at 2 08 58 PM" src="https://user-images.githubusercontent.com/15662960/217953394-9f18a869-03c0-46d6-b0be-e0ad292f3759.png">
<img width="805" alt="Screenshot 2023-02-09 at 2 25 42 PM" src="https://user-images.githubusercontent.com/15662960/217953404-63803c44-f441-4169-88c7-9dffc82108ca.png">
