### PR TITLE
Add playoutDelay parameter to client SDK docs

### DIFF
--- a/docs/client-sdk/javascript/examples.mdx
+++ b/docs/client-sdk/javascript/examples.mdx
@@ -16,7 +16,7 @@ const embedURL = "https://abc.hyperbeam.com/foo?token=bar"
 const container = document.getElementById("container-id")
 
 const hb = await Hyperbeam(container, embedURL, {
-	// Number of milliseconds until the request to the multiplayer browser times out.
+	// Number of milliseconds until the request to the virtual browser times out.
 	// If the request times out, the returned promise will be rejected.
 	timeout: 5000, // default = 2000
 
@@ -24,10 +24,10 @@ const hb = await Hyperbeam(container, embedURL, {
 	// access to managing user permissions and programmatic navigation.
 	adminToken: "admin_token_from_rest_api_response",
 
-	// Starting volume of the multiplayer browser
+	// Starting volume of the virtual browser
 	volume: 0.2,         // default = 1.0
 
-	// Starting video pause state of the multiplayer browser
+	// Starting video pause state of the virtual browser
 	videoPaused: false,  // default = false
 
 	// delegate global keyboard events to the embed
@@ -45,13 +45,13 @@ const hb = await Hyperbeam(container, embedURL, {
 	// Data to be provided to your webhook endpoint if you're using webhook authentication
 	webhookUserdata: {myAppData: {user: "your-app-user-id"}},
 
-	// Callback called when another user moves their mouse cursor on top of the multiplayer browser
+	// Callback called when another user moves their mouse cursor on top of the virtual browser
 	// Useful for implementing multiplayer cursors
 	onCursor({ x, y, userId }) => {},
 
-	// Callback called when the user disconnects from the multiplayer browser
+	// Callback called when the user disconnects from the virtual browser
 	// type is an enum with one of the following values:
-	//   "request"  -> multiplayer browser was manually shut down
+	//   "request"  -> virtual browser was manually shut down
 	//   "inactive" -> inactive timeout was triggered
 	//   "absolute" -> absolute timeout was triggered
 	//   "kick"     -> user was kicked from the session
@@ -74,7 +74,7 @@ const hb = await Hyperbeam(container, embedURL, {
 	// state = "connecting" | "playing" | "reconnecting"
 	//
 	// You can use this to show custom reconnecting UI, and detecting if a user
-	// has a sub-optimal connection to the multiplayer browser
+	// has a sub-optimal connection to the virtual browser
 	onConnectionStateChange: ({ state }) => {}
 })
 ```
@@ -135,7 +135,7 @@ beforeUnmount() {
 ## 🔉 Setting video volume
 `hb.volume = 0.5`
 
-Sets the volume for the multiplayer browser *locally*. Volume changes only apply to the local user. This setting is *not* persisted on refreshing the page.
+Sets the volume for the virtual browser *locally*. Volume changes only apply to the local user. This setting is *not* persisted on refreshing the page.
 
 ```js JavaScript
 const hb = await Hyperbeam(container, embedURL)
@@ -147,7 +147,7 @@ console.log(hb.volume) // Get the local volume value
 ## 🆔 Getting user ID
 `hb.userId: string`
 
-Gets the client's user ID. A "user" is defined as a single connection to the multiplayer browser. If a person has multiple tabs connected to the multiplayer browser, each tab with an active connection will be assigned a different user ID.
+Gets the client's user ID. A "user" is defined as a single connection to the virtual browser. If a person has multiple tabs connected to the virtual browser, each tab with an active connection will be assigned a different user ID.
 
 ```js JavaScript
 const hb = await Hyperbeam(container, embedURL)
@@ -157,7 +157,7 @@ console.log(hb.userId) // A unique string identifying the user
 ## ⏸️ Pausing video stream
 `hb.videoPaused = true`
 
-Pauses/resumes the video stream for the multiplayer browser *locally*. Useful if only the audio component is of interest and you want to minimize CPU usage.
+Pauses/resumes the video stream for the virtual browser *locally*. Useful if only the audio component is of interest and you want to minimize CPU usage.
 
 ```js JavaScript
 const hb = await Hyperbeam(container, embedURL)
@@ -204,7 +204,7 @@ const permissions = {
 
 	// Number of milliseconds until a user is considered "idle". Once a user is considered
 	// idle, they no longer preempt lower priority users until they interact with the
-	// multiplayer browser again.
+	// virtual browser again.
 	idle_timeout: 3000,    // default = 0
 
 	// If control_disabled = true, all control input (mouse movements, keyboard presses)

--- a/docs/client-sdk/javascript/overview.mdx
+++ b/docs/client-sdk/javascript/overview.mdx
@@ -3,12 +3,12 @@ title: Overview
 ---
 
 Among other things, the Hyperbeam client-side JavaScript SDK allows you to:
-- Connect to a multiplayer browser
+- Connect to a virtual browser
 - Control the virtual browser navigation programmatically
 - Query the virtual browser state and listen to events
 - Manage user control permissions
 - Resize the browser
-- Set local multiplayer browser volume
+- Set local virtual browser volume
 
 The library is published on [npm as @hyperbeam/web](https://www.npmjs.com/package/@hyperbeam/web).
 
@@ -50,7 +50,7 @@ $ npm install @hyperbeam/web --save
     How to tear down network connections and browser events.
   </Card>
   <Card title="Setting video volume" icon={<div>🔉</div>} color="#a888ff" href="/client-sdk/javascript/examples#setting-video-volume">
-    How to set the local volume for the multiplayer browser.
+    How to set the local volume for the virtual browser.
   </Card>
   <Card title="Getting user ID" icon={<div>🆔</div>} color="#a888ff" href="/client-sdk/javascript/examples#getting-user-id">
     How to get the client's user ID.

--- a/docs/client-sdk/javascript/reference.mdx
+++ b/docs/client-sdk/javascript/reference.mdx
@@ -32,15 +32,19 @@ const hb = await Hyperbeam(container, embedURL, options)
       </Param>
 
       <Param body="timeout" type="number" default="2000">
-        Number of milliseconds until the request to the multiplayer browser times out. If the request times out, the returned promise will be rejected.
+        Number of milliseconds until the request to the virtual browser times out. If the request times out, the returned promise will be rejected.
       </Param>
 
       <Param body="volume" type="number" default="1.0">
-        Starting volume of the multiplayer browser.
+        Starting volume of the virtual browser.
       </Param>
 
       <Param body="videoPaused" type="boolean" default="false">
-        Starting video pause state of the multiplayer browser.
+        Starting video pause state of the virtual browser.
+      </Param>
+
+      <Param body="hb.playoutDelay" type="boolean" default="false">
+        Starting playout delay state of the virtual browser. When `playoutDelay` = `true`, input lag increases but smoothness is improved and frame drops are reduced.
       </Param>
 
       <Param body="delegateKeyboard" type="boolean" default="true">
@@ -60,12 +64,12 @@ const hb = await Hyperbeam(container, embedURL, options)
       </Param>
 
       <Param body="onCursor" type="(e: PeerMouseEvent) => void">
-    		Callback called when another user moves their mouse cursor on top of the multiplayer browser. Useful for implementing multiplayer cursors.
+    		Callback called when another user moves their mouse cursor on top of the virtual browser. Useful for implementing multiplayer cursors.
       </Param>
 
       <Param body="onDisconnect" type="(e: DisconnectEvent) => void">
-      	Callback called when the user disconnects from the multiplayer browser. `e.type` is an enum with one of the following values:
-				`"request"`  -> multiplayer browser was manually shut down.
+      	Callback called when the user disconnects from the virtual browser. `e.type` is an enum with one of the following values:
+				`"request"`  -> virtual browser was manually shut down.
 				`"inactive"` -> inactive timeout was triggered.
 				`"absolute"` -> absolute timeout was triggered.
 				`"kick"`     -> user was kicked from the session.
@@ -80,7 +84,7 @@ const hb = await Hyperbeam(container, embedURL, options)
 
       <Param body="onConnectionStateChange" type="(e: ConnectionStateEvent) => void">
       	Callback called when the connection state of the video stream has changed. `e.state` = `"connecting" | "playing" | "reconnecting"`.
-				You can use this to show custom reconnecting UI, and detecting if a user has a sub-optimal connection to the multiplayer browser.
+				You can use this to show custom reconnecting UI, and detecting if a user has a sub-optimal connection to the virtual browser.
       </Param>
   </Expandable>
 </Param>
@@ -126,6 +130,10 @@ const hb: Promise<HyperbeamClient> = await Hyperbeam(container, embedURL, option
   Pauses the video stream of the virtual browser locally. [See example.](/client-sdk/javascript/examples#pausing-video-stream)
 </Param>
 
+<Param body="hb.playoutDelay" type="boolean">
+  When `playoutDelay` = `true`, input lag increases but smoothness is improved and frame drops are reduced.
+</Param>
+
 <Param body="hb.tabs" type="Tabs Object">
   The virtual browser Tabs object. [See example.](/client-sdk/javascript/examples#control-tabs-programmatically)
 </Param>
@@ -164,7 +172,7 @@ Sets the permission of a user by their ID. The client must have an admin token s
 			Higher value = higher priority. Users with a higher priority will preempt the control of lower priority users.
 		</Param>
 		<Param body="idle_timeout" type="number">
-			Number of milliseconds until a user is considered "idle". Once a user is considered idle, they no longer preempt lower priority users until they interact with the multiplayer browser again.
+			Number of milliseconds until a user is considered "idle". Once a user is considered idle, they no longer preempt lower priority users until they interact with the virtual browser again.
 		</Param>
 		<Param body="control_disabled" type="boolean" default="<control_disable_default>">
 			If control_disabled = true, all control input (mouse movements, keyboard presses) will be ignored. Note that disabling control does not restrict access to any APIs that require admin tokens.
@@ -188,7 +196,7 @@ Sends a keyboard, mouse, or mouse wheel event to the Hyperbeam browser. [See exa
 #### <Heading hidden>resize</Heading>
 `hb.resize(width, height): void`
 
-Resizes the multiplayer browser to the specified width and height, in pixels. The arguments must meet the following conditions, otherwise the function will throw a `RangeError: width * height cannot be greater than hb.maxArea`.
+Resizes the virtual browser to the specified width and height, in pixels. The arguments must meet the following conditions, otherwise the function will throw a `RangeError: width * height cannot be greater than hb.maxArea`.
 
 `hb.maxArea` is the maximum area that can be allocated in pixels.
 

--- a/docs/rest-api/session/set-user-permission.mdx
+++ b/docs/rest-api/session/set-user-permission.mdx
@@ -14,7 +14,7 @@ authMethod: "bearer"
 <Param body="idle_timeout" type="integer" default={0}>
   Number of milliseconds until a user is considered "idle". Once a user is
   considered idle, they no longer preempt lower priority users until they
-  interact with the multiplayer browser again.
+  interact with the virtual browser again.
 </Param>
 
 <Param


### PR DESCRIPTION
## Summary

- Add playoutDelay parameter to client SDK docs
- Changes "multiplayer browser" to "virtual browser" for better SEO + consistency

